### PR TITLE
Assigning tmploc at course level to allow edXproblem macro directly under edXcourse

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v1.0, 2013-09-22 -- Initial release.
 v1.1, 2014-01-21 -- Support for jsinput, custom mathjax filtering, formularesponse
 v1.2, 2014-06-05 -- General Hints System
 v1.3, 2014-06-22 -- Documentation, edXvideo, edXdiscussion
+v1.4, 2015-01-13 -- Cross-referencing, Table of Content, pop-ups option

--- a/README.md
+++ b/README.md
@@ -156,3 +156,4 @@ History
 *     .2: Fix edXmath environment to use verbatim
 *     .3: Ensure edXinclude doesn't leave contents within a p; nicer error messages for include, with linenum
 *     .4: Include linenum, filename in more error msgs; add --section-only, --xml-only, --units-only output fmts
+* v1.4.0: Enable cross-referencing with \ref and \label; add --popups output fmt for eqns and figs; add ToC generation with \tocref and \toclabel

--- a/README.txt
+++ b/README.txt
@@ -110,3 +110,4 @@ History
 *     .2: Fix edXmath environment to use verbatim
 *     .3: Ensure edXinclude doesn't leave contents within a <p>; nicer error messages for include, with linenum
 *     .4: Include linenum, filename in more error msgs; add --section-only, --xml-only, --units-only output fmts
+* v1.4.0: Enable cross-referencing with \ref and \label; add --popups output fmt for eqns and figs; add ToC generation with \tocref and \toclabel

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -439,6 +439,23 @@ class latex2edx(object):
         for div in tree.findall('.//div[@class="minipage"]'):
             div.tag = 'text'
 
+    def set_tmploc(self, tree, locstr):
+        '''
+        Create a tmploc attribute (if none exists) for the elements:
+          tocref, toclabel, ref, label, index,
+          table class="equation", table class="eqnarray",
+          div class="figure"
+        so as to later be able to reference these items by addressing their
+        location.
+        '''
+        for elem in tree.xpath('.//tocref|.//toclabel|.//label|'
+                               './/table[@class="equation"]|'
+                               './/table[@class="eqnarray"]|'
+                               './/div[@class="figure"]|'
+                               './/ref|.//index'):
+            if elem.get('tmploc') is None:
+                elem.set('tmploc', locstr)
+
     def handle_refs(self, tree):
         '''
         Process references to sections of content -- create section numbering and
@@ -523,28 +540,14 @@ class latex2edx(object):
                     for label in labels:
                         if label is not None:
                             label.set('tmploc', locstr + '.0')
-                    for elem in vert.xpath('.//tocref|.//toclabel|.//label|'
-                                           './/table[@class="equation"]|'
-                                           './/table[@class="eqnarray"]|'
-                                           './/div[@class="figure"]|'
-                                           './/ref|.//index'):
-                        elem.set('tmploc', locstr)
+                    self.set_tmploc(vert, locstr)
                 locstr = '.'.join(locstr.split('.')[:-1])
-                for elem in seq.xpath('.//tocref|.//toclabel|.//label|'
-                                      './/table[@class="equation"]|'
-                                      './/table[@class="eqnarray"]|'
-                                      './/div[@class="figure"]|'
-                                      './/ref|.//index'):
-                    if elem.get('tmploc') is None:
-                        elem.set('tmploc', locstr)
+                self.set_tmploc(seq, locstr)
             locstr = '.'.join(locstr.split('.')[:-1])
-            for elem in chapter.xpath('.//tocref|.//toclabel|.//label|'
-                                      './/table[@class="equation"]|'
-                                      './/table[@class="eqnarray"]|'
-                                      './/div[@class="figure"]|'
-                                      './/ref|.//index'):
-                if elem.get('tmploc') is None:
-                    elem.set('tmploc', locstr)
+            self.set_tmploc(chapter, locstr)
+        # EVH 01-13-15: tmploc assignment added at course level
+        self.set_tmploc(course, '0')
+        mapdict['0'] = ['#', cnumber, '0']
         # EVH: Handle figure references. Search for labels and build dictionary
         figdict = {}  # {'figlabel':'fignum'}
         figattrib = {}  # {'figlabel':{'attrib':'value'}}

--- a/latex2edx/texinputs/edXpsl.sty
+++ b/latex2edx/texinputs/edXpsl.sty
@@ -13,7 +13,7 @@
 \RequirePackage{verbatim}
 \RequirePackage{graphicx}
 \RequirePackage{color}
-\RequirePackage{url}
+\RequirePackage[obeyspaces]{url}
   \cs_set_eq:NN \vurl \url
 \RequirePackage{hyperref}
 \RequirePackage{amsmath}
@@ -57,10 +57,10 @@
 \NewDocumentEnvironment { edXcourse } { m m o }
  {
   \ReNewDocumentCommand \CourseDisplay { } {#2}
-  \ReNewDocumentCommand \CourseNumber { } { \texttt{#1}}
+  \ReNewDocumentCommand \CourseNumber { } { \urlstyle{rm} \vurl{#1} }
   \IfNoValueTF {#3}
    { } {
-    \ReNewDocumentCommand \CourseOptions { } { \texttt{#3} }
+    \ReNewDocumentCommand \CourseOptions { } { \urlstyle{rm} \vurl{#3} }
    }
   \group_begin:
   \title
@@ -69,7 +69,7 @@
     \vspace {1em}
     {\Huge edX ~ Course: ~ #1}\\
     \vspace {1em}
-    \IfNoValueTF {#3} { } {\texttt {#3} }
+    \IfNoValueTF {#3} { } { \CourseOptions }
    }
   \group_end:
   \maketitle

--- a/latex2edx/texinputs/edXpsl.sty
+++ b/latex2edx/texinputs/edXpsl.sty
@@ -4,7 +4,8 @@
 % Style file for compiling MITx course to PDF using the 'article' document class.
 
 % Note:
-% Directives using the \def command included in the main course TEX file are interpreted by both the LaTeX => PDF converters and latex2edx executable.
+% Directives using the \def command included in the main course TEX file are
+% interpreted by both the LaTeX => PDF converters and the latex2edx executable.
 
 \RequirePackage{xparse}
 \ExplSyntaxOn
@@ -32,6 +33,7 @@
 \RequirePackage[T1]{fontenc}
 \RequirePackage{titling}
 
+\makeindex
 %Set up table of contents entries
 \ProvideDocumentCommand \phantomsection { } { }
 \NewDocumentCommand \addchaptoc { m } { \phantomsection \addcontentsline {toc} {section} {#1} }
@@ -43,6 +45,10 @@
 \date { \today }
 \author { }
 
+\NewDocumentCommand \CourseDisplay { } {~}
+\NewDocumentCommand \CourseNumber { } {~}
+\NewDocumentCommand \CourseOptions { } {~}
+
 % edX commands understood by latex2edx.py
 \newcounter { edXchapter }
 \newcounter { edXsequential } [ edXchapter ]
@@ -50,13 +56,11 @@
 
 \NewDocumentEnvironment { edXcourse } { m m o }
  {
-  \NewDocumentCommand \CourseDisplay { } {#2}
-  \NewDocumentCommand \CourseNumber { } {#1}
+  \ReNewDocumentCommand \CourseDisplay { } {#2}
+  \ReNewDocumentCommand \CourseNumber { } { \texttt{#1}}
   \IfNoValueTF {#3}
-   {
-    \NewDocumentCommand \CourseOptions { } {~}
-   } {
-    \NewDocumentCommand \CourseOptions { } { \texttt{#3} }
+   { } {
+    \ReNewDocumentCommand \CourseOptions { } { \texttt{#3} }
    }
   \group_begin:
   \title
@@ -70,6 +74,8 @@
   \group_end:
   \maketitle
   \tableofcontents
+  \newpage
+  \printindex
   \newpage
  } { }
 
@@ -224,9 +230,11 @@
     \fbox
      {
       \parbox {0.9 \hsize}
-      \group_begin:
-       \texttt {#1}
-      \group_end:
+      {
+       \group_begin:
+        \texttt {#1}
+       \group_end:
+      }
      }
    } {
     \group_begin:

--- a/latex2edx/texinputs/edXpsl16.sty
+++ b/latex2edx/texinputs/edXpsl16.sty
@@ -13,7 +13,7 @@
 \RequirePackage{verbatim}
 \RequirePackage{graphicx}
 \RequirePackage{color}
-\RequirePackage{url}
+\RequirePackage[obeyspaces]{url}
   \cs_set_eq:NN \vurl \url
 \RequirePackage{hyperref}
 \RequirePackage{amsmath}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ data_files = [
 
 setup(
     name='latex2edx',
-    version='1.3.4a',
+    version='1.4.0',
     author='I. Chuang',
     author_email='ichuang@mit.edu',
     packages=['latex2edx', 'latex2edx.test'],


### PR DESCRIPTION
Created a subfunction to assign the tmploc attribute to elements in a streamlined fashion.
Assigned a value to elements directly under the edXcourse level allows the compilation of LaTeX files without the need of adding edXchapter and other structural macros before the lowest level elements (edXproblem and edXtext).

Also added index generation to the edXpsl.sty file under texinputs/