### PR TITLE
Enabled starred versions of \section commands, and specification of can_reuse=false

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1370,7 +1370,7 @@ class latex2edx(object):
                     run_latex2dnd = True
             if run_latex2dnd:
                 options = ''
-                if dndxml.get('can_reuse', False):
+                if dndxml.get('can_reuse', 'False').lower().strip() != 'false':
                     options += '-C'
                 cmd = 'cd "%s"; latex2dnd -r %s -v %s %s.tex' % (fndir, dndxml.get('resolution', 210), options, fnpre)
                 print "--> Running %s" % cmd

--- a/latex2edx/plastexpy/edXpsl.py
+++ b/latex2edx/plastexpy/edXpsl.py
@@ -200,11 +200,15 @@ class edXsolution(MyBaseEnvironment):
 
 
 class section(Base.Command):
-    args = 'self'
+    args = '* self'
 
 
 class subsection(Base.Command):
-    args = 'self'
+    args = '* self'
+
+
+class subsubsection(Base.Command):
+    args = '* self'
 
 
 class label(Base.Command):

--- a/latex2edx/render/edXpsl.zpts
+++ b/latex2edx/render/edXpsl.zpts
@@ -79,7 +79,7 @@ name: section
 name: subsection
 <h3 tal:content='self'></h3>
 
-name: subsection
+name: subsubsection
 <h4 tal:content='self'></h4>
 
 name: label

--- a/latex2edx/texinputs/edXpsl.sty
+++ b/latex2edx/texinputs/edXpsl.sty
@@ -220,18 +220,34 @@
 
 \NewDocumentEnvironment { edXjavascript } { }
  {
-  \verbatim
+  \ifthenelse
+   {
+    \boolean { showJava }
+   } {
+    \noindent
+    \underline { \texttt { JavaScript ~ code: } }
+    \verbatim
+   } {
+    \comment
+   }
  } {
-  \endverbatim
+  \ifthenelse
+   {
+    \boolean { showJava }
+   } {
+    \endverbatim
+   } {
+    \endcomment
+   }
  }
 
 \NewDocumentEnvironment { edXmath } { } { } { }
 
-\NewDocumentCommand \edXgitlink   { m m } { \href {#1} { \cleanname{#2} } }
+\NewDocumentCommand \edXgitlink   { m m } { \href {#1} { \color{blue} \underline{ \cleanname{#2} } } }
 \NewDocumentCommand \edXinline    { m } {#1}
 \NewDocumentCommand \edXinclude   { m } { \texttt {#1} }
-\NewDocumentCommand \edXincludepy { m } { }
-\NewDocumentCommand \edXdndtex    { m } { }
+\NewDocumentCommand \edXincludepy { m } { \texttt {#1} }
+\NewDocumentCommand \edXdndtex    { m } { \texttt {#1} }
 \NewDocumentCommand \edXxml       { m } { \texttt {#1} }
 \NewDocumentCommand \edXbr        { } { \par }
 
@@ -342,6 +358,8 @@
 \setboolean { showSolution } {false}
 \newboolean { showPython }
 \setboolean { showPython } {false}
+\newboolean { showJava }
+\setboolean { showJava } {false}
 
 \cs_new:Npn \edx_header_line_format:nn #1#2
  {

--- a/latex2edx/texinputs/edXpsl.sty
+++ b/latex2edx/texinputs/edXpsl.sty
@@ -225,12 +225,7 @@
   \endverbatim
  }
 
-\NewDocumentEnvironment { edXmath } { }
- {
-  \begin{displaymath}
- } {
-  \end{displaymath}
- }
+\NewDocumentEnvironment { edXmath } { } { } { }
 
 \NewDocumentCommand \edXgitlink   { m m } { \href {#1} { \cleanname{#2} } }
 \NewDocumentCommand \edXinline    { m } {#1}


### PR DESCRIPTION
Also renamed the redundant subsection to subsubsection
The draggable option can_reuse was set to true if the attribute existed in the options list.  Does not resolve the issue that a different setting of can_reuse in a DND tex file is ignored.  Although that issue arises in latex2dnd.