### PR TITLE
Improved behavior of edXxml and added test

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -882,7 +882,7 @@ class latex2edx(object):
                                      eqncontent, re.S) is not None:
                             eqnlabel = re.findall(r'\\label\{(.*?)\}',
                                                   eqncontent, re.S)
-                            eqncontent = re.sub(r'\\label{.*}', r'',
+                            eqncontent = re.sub(r'\\label{.*?}', r'',
                                                 eqncontent)
                             td.text = eqncontent
                 if len(eqnlabel) != 0:
@@ -1184,22 +1184,31 @@ class latex2edx(object):
             where2add = p
             p = p.getparent()
 
-        # move from xml to parent
+        # move from xml to parent: text, children, and tail
         if xml.text:
-            if p.text:
-                p.text += xml.text
+            if xml.getprevious() is not None:
+                if xml.getprevious().tail:
+                    xml.getprevious().tail += xml.text
+                else:
+                    xml.getprevious().tail = xml.text
             else:
-                p.text = xml.text
+                if p.text:
+                    p.text += xml.text
+                else:
+                    p.text = xml.text
         for child in xml:
             where2add.addprevious(child)
         if xml.tail:
-            if len(p.getchildren()) != 0:
-                if p.getchildren()[-1].tail:
-                    p.getchildren()[-1].tail += xml.tail
+            if 'child' in locals():
+                if child.tail:
+                    child.tail += xml.tail
                 else:
-                    p.getchildren()[-1].tail = xml.tail
+                    child.tail = xml.tail
             else:
-                p.text += xml.tail
+                if p.text:
+                    p.text += xml.tail
+                else:
+                    p.text = xml.tail
         p.remove(todrop)
 
     def process_edxxml(self, tree):

--- a/latex2edx/test/test_edxxml.py
+++ b/latex2edx/test/test_edxxml.py
@@ -1,0 +1,47 @@
+'''
+Test XML insertion using the `edXxml` command with example13_edxxml.tex
+'''
+import os
+import unittest
+from path import path  # needs path.py
+
+import latex2edx as l2e
+from latex2edx.main import latex2edx
+from latex2edx.test.util import make_temp_directory
+
+
+class TestEdxxml(unittest.TestCase):
+    '''
+    This class inherits the `unittest.TestCase` class and contains the methods
+    `test_edxxml1` that test the proper functionality of the latex2edx
+    `edXxml` command, properly parsing all text, children, and tail text
+    contained therein.
+    '''
+
+    def test_edxxml1(self):
+        '''
+        Test the output of `latex2edx example13_edxxml.tex` for proper
+        rendering of the complete XML with multiple calls in `edXxml` in a
+        given line.
+        '''
+        testdir = path(l2e.__file__).parent / 'testtex'
+        tfn = testdir / 'example13_edxxml.tex'
+        print "file %s" % tfn
+        with make_temp_directory() as tmdir:
+            nfn = '%s/%s' % (tmdir, tfn.basename())
+            os.system('cp %s/* %s' % (testdir, tmdir))
+            os.chdir(tmdir)
+            l2eout = latex2edx(nfn, output_dir=tmdir)
+            l2eout.convert()
+
+            cfn = path(tmdir) / 'html/Code_Text.xml'
+            data = open(cfn).read().split('\n')
+            expected = ('A matrix <code>A</code> and column vector named '
+                        '<code>b</code> can be multiplied in the form '
+                        '<code>A b</code> only if the number of columns '
+                        'of <code>b</code> match the number of rows in '
+                        '<code>A</code>. </p>')
+            self.assertEqual(data[2], expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/latex2edx/test/test_toc.py
+++ b/latex2edx/test/test_toc.py
@@ -74,8 +74,12 @@ class TestToC(unittest.TestCase):
             cfn = path(tmdir) / 'html/text-L1.xml'
             data = open(cfn).read()
             xml = etree.fromstring(data)
-            href = xml.findall('.//a[@href]')
+            # Check the first equation
+            eqn = xml.find('.//table[@class="equation"]')
+            self.assertEqual(eqn[0][0].text,
+                             '[mathjax] \\frac{d}{dx} e^ x = e^ x[/mathjax]')
             # Check the reference link text
+            href = xml.findall('.//a[@href]')
             self.assertEqual(href[0].text, '0')  # Non-numbered chapter
             self.assertEqual(href[1].text, '(1.2)')  # Numbered equation 2
             self.assertEqual(href[2].text, '(1.3)')  # Numbered equation 3

--- a/latex2edx/testtex/example11_toc_test.tex
+++ b/latex2edx/testtex/example11_toc_test.tex
@@ -94,8 +94,8 @@ In Section \ref{chap:intro} we saw example figure references.  Here are some equ
 
 Example equation:
 \begin{equation}
-  \frac{d}{dx} e^x = e^x
   \label{eq:deriv}
+  \frac{d}{dx} e^x = e^x
 \end{equation}
 
 Example equation array:

--- a/latex2edx/testtex/example13_edxxml.tex
+++ b/latex2edx/testtex/example13_edxxml.tex
@@ -1,0 +1,33 @@
+%
+% File: example13_edxxml.tex
+%
+% Description: Test \edXxml command
+%
+
+\documentclass[12pt]{article}
+\usepackage{edXpsl} % edX style file
+
+\begin{document}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{edXcourse}{1.00x}{1.00x Fall 2014}[url_name=2014_Fall showanswer=always start=2014-10-06T12:00]
+
+%%====================================== CHAPTER 1
+\begin{edXchapter}{Chapter 1}[start="2014-10-04"]
+
+%%-------------------------------------- SEQUENTIAL 1-1
+\begin{edXsequential}{A text section}
+
+\begin{edXtext}{Code Text}
+
+A matrix \edXxml{<code>A</code>} and column vector \edXxml{named <code>b</code> can be multiplied} in the form \edXxml{<code>A b</code>} only if the number of columns of \edXxml{<code>b</code>} match the number of rows in \edXxml{<code>A</code>}.
+
+\end{edXtext}
+
+\end{edXsequential}
+
+\end{edXchapter}
+
+%%======================================
+\end{edXcourse}
+
+\end{document}


### PR DESCRIPTION
The edXxml command in latex2edx ignored text outside of an XML tag.  This has been modified, and a test was written to insure proper handling of leading and trailing (tail) text.

Also modified example11 to test the issue of a greedy string replacement with the \label command in an equation environment.