### PR TITLE
if locstr missing in building reference, skip

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -867,6 +867,8 @@ class latex2edx(object):
         for table in tree.xpath('.//table[@class="equation"]|'
                                 './/table[@class="eqnarray"]'):
             locstr = table.attrib.pop('tmploc')
+            if not locstr:
+                continue
             locref = mapdict[locstr][2]
             if chapref != locref.split('.')[0]:
                 chapref = locref.split('.')[0]


### PR DESCRIPTION
having an empty locstr was causing latex2edx to raise an exception, for me.