### PR TITLE
unescape escaped percentage signs in edxxml strings

### DIFF
--- a/latex2edx/plastexit.py
+++ b/latex2edx/plastexit.py
@@ -52,6 +52,7 @@ class MyRenderer(XHTML.Renderer):
         xmlstr = m.group(1)
         xmlstr = xmlstr.replace('\\$ ','$')	# dollar sign must be escaped in plasTeX, but shouldn't be in XML
         xmlstr = xmlstr.replace('& ', '&')  # remove ampersand space from plasTeX
+        xmlstr = xmlstr.replace('\\% ', '%')  # unescape percentage sign
         # return xmlstr
         return "<edxxml>%s</edxxml>" % xmlstr
 


### PR DESCRIPTION
when a percentage sign is used within an edxxml statement, e.g.:

    \edXxml{<xvideo data="\%20onbar"/>}

this renders incorrectly as

    <xvideo data="\% 20onbar"/>

This PR fixes the behavior, so the output is

    <xvideo data="%20onbar"/>
   
