### PR TITLE
Feature/ichuang/html5 video

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -167,6 +167,7 @@ class latex2edx(object):
                             self.process_dndtex,  # must come before process_include
                             self.process_include,
                             self.process_includepy,
+                            self.process_video,
                             self.process_general_hint_system,
                             self.check_all_python_scripts,
                             self.handle_policy_settings,
@@ -1221,6 +1222,19 @@ class latex2edx(object):
         '''
         for edxxml in tree.findall('.//edxxml'):
             self.remove_parent_p(edxxml)
+
+    def process_video(self, tree):
+        '''
+        If the "youtubeid" begins with "http" then make the video an html5 video.
+        '''
+        for video in tree.findall('.//video'):
+            ytid = video.get('youtube_id_1_0')
+            if ytid.startswith('http'):
+                video.set('html5_sources', '["%s"]' % ytid)
+                video.set('youtube_id_1_0', '')
+                vsource = etree.Element('source')
+                vsource.set('src', ytid)
+                video.append(vsource)
 
     def process_showhide(self, tree):
         for showhide in tree.findall('.//edxshowhide'):

--- a/latex2edx/plastexit.py
+++ b/latex2edx/plastexit.py
@@ -52,6 +52,7 @@ class MyRenderer(XHTML.Renderer):
         xmlstr = m.group(1)
         xmlstr = xmlstr.replace('\\$ ','$')	# dollar sign must be escaped in plasTeX, but shouldn't be in XML
         xmlstr = xmlstr.replace('& ', '&')  # remove ampersand space from plasTeX
+        xmlstr = xmlstr.replace('\\% ', '%')  # unescape percentage sign
         # return xmlstr
         return "<edxxml>%s</edxxml>" % xmlstr
 


### PR DESCRIPTION
Allow edXvideo to specify a URL instead of a youtube-id, for a HTML5 video, e.g.:

    \edXvideo{Concept Question 1: limits on frequency measurement}{http://my-video-server/M1L1a-CQ1.mp4}

Very handy for using a local file server for videos (e.g. nginx + mp4), instead of youtube.