### PR TITLE
skip refs code if doing units-only

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -468,8 +468,12 @@ class latex2edx(object):
         '''
         if self.section_only:
             return
+        if self.units_only:
+            return
         # EVH: Build course map from tree.
         course = tree.find('.//course')
+        if not course:
+            return
         cnumber = course.get('number')
         # EVH: Navigate course and set a 'tmploc' attribute with location for desired items
         maplist = []  # ['loc. str.']
@@ -1554,7 +1558,7 @@ class latex2edx(object):
                '&': 'and',
                '[': 'LB_',
                ']': '_RB',
-               '?# ': '_',
+               '?#* ': '_',
                }
         if not s:
             s = tag


### PR DESCRIPTION
This tex should compile cleanly with latex2edx --units-only:

\documentclass[12pt]{article}

\usepackage{edXpsl}

\begin{document}

\begin{edXproblem}{testing}{display_name="Test problem" showanswer="past_due" weight="0"}

This is a test.

\edXabox{type="formula" expect="x" samples="x,y@1,1:3,3#2" math="1" tolerance="0.1\%" size="60" inline="1"}

\end{edXproblem}

\end{document}