### PR TITLE
insert newline after edXxml if not present

### DIFF
--- a/latex2edx/plastexit.py
+++ b/latex2edx/plastexit.py
@@ -392,6 +392,9 @@ class plastex2xhtml(object):
                     newstring.append('')
                 insert_nl = False
 
+            if line.startswith('\edXxml{'):	# special case: add newline for this
+                insert_nl = True
+
             if not r'\begin' in line:
                 newstring.append(line)
                 continue


### PR DESCRIPTION
This test case did not compile, before this PR fix:

\documentclass{article}
\usepackage{edXpsl}     % edX

\begin{document}

\begin{edXproblem}{This is a test}{url_name="testing"}

\edXxml{}
Add a CRLF above or below this line and everything is fine. You can do something tiny in the tags if you like (eg, an open bold and close bold).
\edXxml{}

\end{edXproblem}

\end{document}

(courtesy of Jolyon)