### PR TITLE
Allow subdirectories in xml structure

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Saif Rayyan <srayyan@mit.edu>
 Chad Lieberman <chad.e.lieberman@gmail.com>
 Ben Weeks <benweeks@mit.edu>
 Eric Heubel <evheubel@mit.edu>
+Jolyon Bloomfield <jolyon@mit.edu>

--- a/latex2edx/xbundle.py
+++ b/latex2edx/xbundle.py
@@ -107,7 +107,7 @@ DEF_GRADING_POLICY_JSON = """
 
 class XBundle(object):
     '''
-    An XBundle is defined by two elements: course and metadata.  
+    An XBundle is defined by two elements: course and metadata.
     metadata includes policies and about.
     '''
 
@@ -129,7 +129,7 @@ class XBundle(object):
         '''
         if keep_urls=True then the original url_name attributes are kept upon import and export,
         if nonrandom (ie non-Studio).
-        
+
         if keep_studio_urls=True and keep_urls=True, then keep random urls.
 
         no_overwrite: optional list of xml tags for which files should not be overwritten (eg course)
@@ -146,7 +146,7 @@ class XBundle(object):
         self.overwrite_files = []
         return
 
-        
+
     #----------------------------------------
     # creation by parts
 
@@ -171,8 +171,8 @@ class XBundle(object):
                     for child in xml:
                         walk(child)
             walk(xml)
-    
-        
+
+
     def add_policies(self, policies):
         '''add a policies XML subtree to the metadata'''
         self.metadata.append(policies)
@@ -190,7 +190,7 @@ class XBundle(object):
         abfile.text = filedata.decode('utf-8')
 
     #----------------------------------------
-    # load/save 
+    # load/save
 
     def load(self, fn):
         """
@@ -233,7 +233,7 @@ class XBundle(object):
         self.metadata = etree.Element('metadata')
         self.import_metadata_from_directory(dir)
         self.import_course_from_directory(dir)
-        
+
 
     def import_metadata_from_directory(self, dir):
         # load policies
@@ -246,7 +246,7 @@ class XBundle(object):
                 x = etree.SubElement(policies,os.path.basename(fn).replace('_','').replace('.json',''))
                 x.text = open(fn).read()
             self.add_policies(policies)
-        
+
         # load about files
         for afn in glob.glob(dir / 'about/*'):
             try:
@@ -254,7 +254,7 @@ class XBundle(object):
             except Exception as err:
                 print "Oops, failed to add file %s, error=%s" % (afn, err)
 
-                
+
     def import_course_from_directory(self, dir):
         '''load course tree, removing intermediate descriptors with url_name'''
         dir = path(dir)
@@ -267,7 +267,7 @@ class XBundle(object):
         self.fix_old_descriptor_name(self.course)
         # print self.pp_xml(self.course)
 
-        
+
     def fix_old_descriptor_name(self, xml):
         '''
         Turn name -> display_name on descriptor tags
@@ -290,7 +290,7 @@ class XBundle(object):
                     seq.addprevious(k)
                 sect.remove(seq)		# remove sequential from inside section
             sect.tag = 'sequential'
-        
+
 
     def is_not_random_urlname(self, un):
         if self.keep_studio_urls:		# keep url even if random looking
@@ -299,12 +299,12 @@ class XBundle(object):
         nrand = len('55bc076ad06e4ede9d0561948c03be2f')
         if not len(un)==nrand:
             return True
-        ndigits = len([z for z in un if z in string.digits])        
+        ndigits = len([z for z in un if z in string.digits])
         if ndigits<6:
             return True
         return False	# ie seems to be random
 
-        
+
     def update_metadata_from_policy(self, xml):
         # update metadaa for this element from policy, if exists
         policy = getattr(self,'policy')
@@ -317,10 +317,10 @@ class XBundle(object):
                 if xml.get(k,None) is None:	# don't overwrite xml's metadata setting, if exists already
                     xml.set(k,str(v))
 
-        
+
     def import_xml_removing_descriptor(self, dir, xml):
         '''
-        load XML file, recursively following and removing intermediate 
+        load XML file, recursively following and removing intermediate
         descriptors with url_name.
 
         if element is a DescriptorTag element, and display_name is missing, then
@@ -381,7 +381,7 @@ class XBundle(object):
                 #if not fn.startswith('problems/'):
                 #    fn = 'problems/' + fn
                 options = {}
-                
+
             if not os.path.exists(dir/xml.tag/fn):
                 if '-' in fn:
                     fn = '%s/%s' % (fn.split('-',1)[0], fn)
@@ -399,7 +399,7 @@ class XBundle(object):
                 if dxml.tag in self.DescriptorTags and dxml.get('display_name') is None:
                     dxml.set('display_name',un)
                 xml = dxml
-            
+
         if self.skip_hidden:
             self.update_metadata_from_policy(xml)
             if xml.get('hide_from_toc','')=='true':
@@ -459,7 +459,7 @@ class XBundle(object):
             for k in pxml:
                 fn = self.PolicyTagMap.get(k.tag, k.tag) + '.json'
                 open(dir / fn, 'w').write(k.text)  # write out content to policy directory file
-        
+
         adir = self.mkdir(self.dir / 'about')
         for fxml in self.metadata.findall('about/file'):
             fn = fxml.get('filename')
@@ -493,6 +493,11 @@ class XBundle(object):
             if 'url_name_orig' in elem.attrib and self.keep_urls:
                 elem.attrib.pop('url_name_orig')
             edir = self.mkdir(self.dir / x.tag)
+            # Check for any ':' symbols in the url_name and create appropriate subdirectories
+            subdirs = un.split(':')
+            for newdir in subdirs[:-1] :
+                edir = self.mkdir(edir / newdir)
+            un = subdirs[-1]
             self.write_xml_file(edir / un + '.xml', x)
             return un
 
@@ -529,7 +534,7 @@ class XBundle(object):
 
     def errlog(self, msg):
         print msg
-        
+
 
     def mkdir(self, p):
         '''p is a path'''
@@ -722,7 +727,7 @@ if __name__ == '__main__':
         options['force_studio_format'] = True
 
     cmd = sys.argv[argc]
-    
+
     if cmd == 'test':
         RunTests()
 


### PR DESCRIPTION
This adds a command line switch to turn url_names that include a "/" into a ":" rather than a "_". When writing the xml out, it checks for the presence of any colons in the url_name, and creates the appropriate directory structure.

We'd like to use this for 8.01/2.