### PR TITLE
Modification of equation handling

### DIFF
--- a/latex2edx/abox.py
+++ b/latex2edx/abox.py
@@ -387,7 +387,7 @@ class AnswerBox(object):
                 tl = etree.Element('formulaequationinput')
             else:
                 tl = etree.Element('textline')
-                self.copy_attrib(abargs, 'trailing_text', tl)
+            self.copy_attrib(abargs, 'trailing_text', tl)
             self.copy_attrib(abargs, 'size', tl)
             self.copy_attrib(abargs, 'inline', tl)
             self.copy_attrib(abargs, 'math', tl)

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -474,7 +474,7 @@ class latex2edx(object):
             return
         # EVH: Build course map from tree.
         course = tree.find('.//course')
-        if len(course) == 0:
+        if course is None:
             return
         cnumber = course.get('number')
         # EVH: Navigate course and set a 'tmploc' attribute with location for desired items

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -927,7 +927,7 @@ class latex2edx(object):
                         eqnnum = 'NaN'
                     eqnlabel = eqnlabel[0]
                     eqnlabel = eqnlabel.replace(' ', '')
-                    eqndict[eqnlabel] = '({})'.format(eqnnum)
+                    eqndict[eqnlabel] = '{}'.format(eqnnum)
                     # EVH: Set id for linking if pop-up flag is False
                     tr.set('id', 'eqn{}'.format(eqnnum.replace('.', 'p')))
                     eqnattrib[eqnlabel] = {
@@ -1248,10 +1248,10 @@ class latex2edx(object):
             cplist = []
             for key, val in lti.attrib.items():
                 if key.startswith('custom_'):
-                    cplist.append("%s=%s" % (key[7:], val))	# strip "custom_" prefix
+                    cplist.append("%s=%s" % (key[7:], val))  # strip "custom_" prefix
                     lti.attrib.pop(key)
             if cplist:
-                lti.set('custom_parameters', '[%s]' % ', '.join([ '"' + x + '"' for x in cplist ]))
+                lti.set('custom_parameters', '[%s]' % ', '.join(['"' + x + '"' for x in cplist]))
             if self.verbose:
                 print "    lti %s, cp=%s" % (lti, lti.get('custom_parameters'))
 

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -474,7 +474,7 @@ class latex2edx(object):
             return
         # EVH: Build course map from tree.
         course = tree.find('.//course')
-        if not course:
+        if len(course) == 0:
             return
         cnumber = course.get('number')
         # EVH: Navigate course and set a 'tmploc' attribute with location for desired items
@@ -1556,14 +1556,14 @@ class latex2edx(object):
                ']': '_RB',
                '?#* ': '_',
                }
-        if not self.allow_dirs :
+        if not self.allow_dirs:
             map['/'] = '_'
         if not s:
             s = tag
         for m, v in map.items():
             for ch in m:
                 s = s.replace(ch, v)
-        if self.allow_dirs :
+        if self.allow_dirs:
             # Have to do this after the rest of the mapping, as we don't want
             # ': to turn into nothing (ordering in dictionary is not guaranteed)
             s = s.replace('/', ':')

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -672,10 +672,19 @@ class latex2edx(object):
             paref = tocref.getparent()
             paref.text += tocref.tail
             paref.remove(tocref)
-            while paref.tag not in ['html', 'problem']:
+            while paref.tag not in ['html', 'problem', 'vertical']:
                 paref = paref.getparent()
+                pareftag = paref.tag
             # EVH: Prepend letter to identify content type
-            if paref.tag == 'problem':
+            if pareftag == 'vertical':
+                parind = []
+                for i, child in enumerate(paref):
+                    if child.tag in ['html', 'problem']:
+                        parind = min(parind, i)
+                    if child.tag == 'problem':
+                        pareftag = 'problem'
+                paref = paref[parind]
+            if pareftag == 'problem':
                 parefname = 'P' + paref.get('display_name')
                 oldtag = paref.get('measureable_outcomes')
                 tagname = tagref

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -888,6 +888,20 @@ class latex2edx(object):
                 for td in tr.findall('.//td'):
                     if td.get('class') == 'eqnnum':
                         eqnnumcell = td
+                        # EVH: Use plasTeX output to handle equation numbering
+                        eqncnt += 1
+                        if chapref == '0':
+                            eqnnum = '{}'.format(eqncnt)
+                        else:
+                            eqnnum = '{}.{}'.format(chapref, eqncnt)
+                        tr.remove(eqnnumcell)
+                        eqnnumcell = etree.SubElement(
+                            tr, "td", attrib=eqnnumcell.attrib)
+                        eqnnumcell.text = '({})'.format(eqnnum)
+                        eqnnumsty = eqnnumcell.get('style')
+                        eqnnumsty = re.sub('text-align:[a-zA-Z]+;', '', eqnnumsty)
+                        eqnnumsty += ';text-align:right'
+                        eqnnumcell.set('style', eqnnumsty)
                     elif td.text is not None:
                         eqncontent = td.text
                         if re.search(r'\\label\{(.*?)\}',
@@ -898,13 +912,12 @@ class latex2edx(object):
                                                 eqncontent)
                             td.text = eqncontent
                 if len(eqnlabel) != 0:
+                    # NOTE: EVH 2015-07-24 find a better way to handle labels
+                    # to unnumbered equations
+                    if eqnnumcell is None:
+                        eqnnum = 'NaN'
                     eqnlabel = eqnlabel[0]
-                    eqncnt += 1
                     eqnlabel = eqnlabel.replace(' ', '')
-                    if chapref == '0':
-                        eqnnum = '{}'.format(eqncnt)
-                    else:
-                        eqnnum = '{}.{}'.format(chapref, eqncnt)
                     eqndict[eqnlabel] = '({})'.format(eqnnum)
                     # EVH: Set id for linking if pop-up flag is False
                     tr.set('id', 'eqn{}'.format(eqnnum.replace('.', 'p')))
@@ -942,33 +955,6 @@ class latex2edx(object):
                     eqnattrib[eqnlabel]['onClick'] = (
                         "return newWindow({}, \'Equation {}\');".
                         format(htmlstr, eqnnum))
-                # replace the necessary subelements to get desired behavior
-                if table.get('class') == 'equation':
-                    # Only one 'tr' element in equation table, need to add 'td'
-                    tr.clear()
-                    eqncell = etree.SubElement(
-                        tr, "td", attrib={
-                            'style': ("width:80%;vertical-align:middle;"
-                                      "text-align:center;border-style:hidden"),
-                            'class': "equation"})
-                    eqncell.text = eqncontent
-                    eqnnumcell = None
-                if eqnnumcell is None:
-                    eqnnumcell = etree.SubElement(
-                        tr, "td", attrib={
-                            'style': ("width:20%;vertical-align:middle;"
-                                      "text-align:left;border-style:hidden"),
-                            'class': "eqnnum"})
-                else:
-                    tr.remove(eqnnumcell)
-                    eqnnumcell = etree.SubElement(
-                        tr, "td", attrib=eqnnumcell.attrib)
-                if len(eqnlabel) != 0:
-                    eqnnumcell.text = '({})'.format(eqnnum)
-                    eqnnumsty = eqnnumcell.get('style')
-                    eqnnumsty = re.sub('text-align:[a-zA-Z]+;', '', eqnnumsty)
-                    eqnnumsty += ';text-align:right'
-                    eqnnumcell.set('style', eqnnumsty)
 
         # EVH: Build keymap dictionary for keywords specified by the \index
         # command

--- a/latex2edx/plastexit.py
+++ b/latex2edx/plastexit.py
@@ -36,7 +36,8 @@ class MyRenderer(XHTML.Renderer):
             self.filters[ffm] = self.filter_fix_math
         for ffm in self.filter_fix_displaymath_match:
             self.filters[ffm] = self.filter_fix_displaymath
-        self.filters[self.filter_fix_displaymathverbatim_match] = self.filter_fix_displaymathverbatim
+        for ffm in self.filter_fix_displaymathverbatim_match:
+            self.filters[ffm] = self.filter_fix_displaymathverbatim
         self.filters[self.filter_fix_abox_match] = self.filter_fix_abox
         self.filters[self.filter_fix_abox_match_with_linenum] = self.filter_fix_abox_with_linenum
         self.filters[self.filter_fix_image_match] = self.filter_fix_image
@@ -91,7 +92,9 @@ class MyRenderer(XHTML.Renderer):
             return "&nbsp;"
         return '[mathjax]%s[/mathjax]' % x
         
-    filter_fix_displaymathverbatim_match = r'(?s)<displaymathverbatim>\\begin{edXmath}(.*?)\\end{edXmath}</displaymathverbatim>'
+    filter_fix_displaymathverbatim_match = [r'(?s)<displaymathverbatim>\\begin{edXmath}(.*?)\\end{edXmath}</displaymathverbatim>',
+                                            r'(?s)<displaymathverbatim>\\edXmath(.*?)</displaymathverbatim>',
+                                            ]
 
     @classmethod
     def filter_fix_displaymathverbatim(cls, m):

--- a/latex2edx/plastexit.py
+++ b/latex2edx/plastexit.py
@@ -98,7 +98,8 @@ class MyRenderer(XHTML.Renderer):
 
     @classmethod
     def filter_fix_displaymathverbatim(cls, m):
-        return '[mathjax]%s[/mathjax]' % escape(m.group(1).strip())
+        x = escape(m.group(1).strip())
+        return '[mathjax]%s[/mathjax]' % x.replace('\\end{edXmath}', '')
 
     filter_fix_image_match = '<includegraphics style="(.*?)">(.*?)</includegraphics>'
 

--- a/latex2edx/plastexit.py
+++ b/latex2edx/plastexit.py
@@ -79,6 +79,7 @@ class MyRenderer(XHTML.Renderer):
         return '[mathjaxinline]%s[/mathjaxinline]' % x
         
     filter_fix_displaymath_match = [r'(?s)<math>\\begin{equation}(.*?)\\end{equation}</math>',
+                                    r'(?s)<math>\\begin{equation\*}(.*?)\\end{equation\*}</math>',
                                     r'(?s)<displaymath>\\begin{edXmath}(.*?)\\end{edXmath}</displaymath>',
                                     r'(?s)<math>\\\[(.*?)\\\]</math>',
                                     ]
@@ -379,6 +380,7 @@ class plastex2xhtml(object):
                            'edXtext',
                            'edXproblem',
                            'edXsolution',
+                           'edXshowhide',
                            ]
 
         newstring = []

--- a/latex2edx/render/Math.zpts
+++ b/latex2edx/render/Math.zpts
@@ -1,10 +1,11 @@
 name: math ensuremath
 <math tal:content='self/source'></math>
 
-name: displaymath equation
+name: displaymath equation equation*
 <table class="equation" width="100%" tal:attributes="id self/id" cellspacing="0" cellpadding="7">
 <tr>
-    <td class='equation'><math tal:content='self/source'></math></td>
+    <td class='equation' style="width:80%"><math tal:content='self/source'></math></td>
+    <td class="eqnnum" style="width:20%"><span tal:condition="self/ref">(<span tal:content="self/ref">1.1.1</span>)</span></td>
 </tr>
 </table>
 

--- a/latex2edx/test/test_toc.py
+++ b/latex2edx/test/test_toc.py
@@ -58,28 +58,26 @@ class TestToC(unittest.TestCase):
                                         re.S)[0], 'eq:pythagorean')
             tocfn = '%s/tabs/tocindex.html' % tmdir
             toc = etree.fromstring(open(tocfn).read().replace('<br>', '<br/>'))
-            toctitle = toc.find('.//h1')
-            self.assertEqual(toctitle.text, 'Table of Contents')
+            self.assertEqual(toc.findtext('body/h1'), 'Table of Contents')
             # Check the measurable outcome table headers
-            # table>tbody>tr>th>a>strong
-            toctabs = toc.findall('.//table')
-            self.assertEqual(toctabs[0][0][0][0][0][0].text, '0')
-            self.assertEqual(toctabs[1][0][0][0][0][0].text, 'MO1')
-            self.assertEqual(toctabs[2][0][0][0][0][0].text, 'MO2')
-            # table>tbody>tr>th>span
+            tocmos = toc.findall('.//table/tbody/tr/th/a')
+            self.assertEqual(tocmos[0][0].text, '0')
+            self.assertEqual(tocmos[1][0].text, 'MO1')
+            self.assertEqual(tocmos[2][0].text, 'MO2')
             self.assertIn('Explore the edX platform',
-                          toctabs[1][0][0][0][1].text)
+                          tocmos[1].getnext().text)
             self.assertIn('Answer an edX question',
-                          toctabs[2][0][0][0][1].text)
-            # check example 'Learn' link
-            self.assertEqual(toctabs[1][0][1][0][0].text, 'Learn')
-            self.assertIn('Example text', toctabs[1][0][1][0][1][0][0].text)
-            # check example 'Assess' link
-            self.assertEqual(toctabs[0][0][1][0][2].text, 'Assess')
-            self.assertIn('Example problem', toctabs[0][0][1][0][3][0][0].text)
-            self.assertIn('Example problem', toctabs[1][0][1][0][3][0][0].text)
-            self.assertIn('Example problem', toctabs[2][0][1][0][3][0][0].text)
-            # tocbod = toc.find('.//body')
+                          tocmos[2].getnext().text)
+            # check measurable outcomes subheadings
+            tocsubs = toc.find('.//table/tbody/tr/td')
+            self.assertEqual(tocsubs[0].text, 'Learn')
+            self.assertEqual(tocsubs[2].text, 'Assess')
+            # check reference to measurable outcomes
+            tocrefs = toc.findall('.//table/tbody/tr/td/ul/li/a')
+            self.assertIn('Example problem', tocrefs[0].text)
+            self.assertIn('Example text', tocrefs[1].text)
+            self.assertIn('Example problem', tocrefs[2].text)
+            self.assertIn('Example problem', tocrefs[3].text)
             self.assertEqual(toc[1][8].tag, 'br')
             self.assertIn('Module 1', toc[1][9][0].text)
 
@@ -139,19 +137,23 @@ class TestToC(unittest.TestCase):
 
             tocfn = '%s/tabs/tocindex.html' % tmdir
             toc = etree.fromstring(open(tocfn).read().replace('<br>', '<br/>'))
-            toctitle = toc.find('.//h1')
-            self.assertEqual(toctitle.text, 'Table of Contents')
-            toctabs = toc.findall('.//table')
-            self.assertEqual(toctabs[0][0][0][0][0][0].text, 'MO1.1')
-            self.assertEqual(toctabs[1][0][0][0][0][0].text, 'MO1.2')
-            self.assertIn('Follow a Lesson',
-                          toctabs[0][0][0][0][1].text)
-            self.assertEqual(toctabs[0][0][1][0][0].text, 'Learn')
-            self.assertIn('Example text', toctabs[0][0][1][0][1][0][0].text)
-            self.assertIn('Answer a problem set',
-                          toctabs[1][0][0][0][1].text)
-            self.assertEqual(toctabs[1][0][1][0][2].text, 'Assess')
-            self.assertIn('Problem Set 1', toctabs[1][0][1][0][3][0][0].text)
+            self.assertEqual(toc.findtext('body/h1'), 'Table of Contents')
+            # Check the measurable outcome table headers
+            tocmos = toc.findall('.//table/tbody/tr/th/a')
+            self.assertEqual(tocmos[0][0].text, 'MO1.1')
+            self.assertEqual(tocmos[1][0].text, 'MO1.2')
+            self.assertIn('Follow a Lesson', tocmos[0].getnext().text)
+            self.assertIn('Answer a problem set', tocmos[1].getnext().text)
+            # check measurable outcomes subheadings
+            tocsubs = toc.find('.//table/tbody/tr/td')
+            self.assertEqual(tocsubs[0].text, 'Learn')
+            self.assertEqual(tocsubs[2].text, 'Assess')
+            # check reference to measurable outcomes
+            tocref1 = toc.find('.//table/tbody/tr[@id="indmo1p1"]/td/ul/li/a')
+            self.assertIn('Example text', tocref1.text)
+            tocref2 = toc.find('.//table/tbody/tr[@id="indmo1p2"]/td/ul/li/a')
+            self.assertIn('Problem Set 1', tocref2.text)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/latex2edx/test/test_toc.py
+++ b/latex2edx/test/test_toc.py
@@ -81,8 +81,8 @@ class TestToC(unittest.TestCase):
             # Check the reference link text
             href = xml.findall('.//a[@href]')
             self.assertEqual(href[0].text, '0')  # Non-numbered chapter
-            self.assertEqual(href[1].text, '(1.2)')  # Numbered equation 2
-            self.assertEqual(href[2].text, '(1.3)')  # Numbered equation 3
+            self.assertEqual(href[1].text, '1.2')  # Numbered equation 2
+            self.assertEqual(href[2].text, '1.3')  # Numbered equation 3
             # Check for popup format
             self.assertEqual(href[1].get('href'), 'javascript: void(0)')
             self.assertEqual(href[2].get('href'), 'javascript: void(0)')

--- a/latex2edx/testtex/example17_toc_vert.tex
+++ b/latex2edx/testtex/example17_toc_vert.tex
@@ -1,0 +1,110 @@
+%
+% File: example17_toc_vert.tex
+%
+% Description: Test \label, \ref, \toclabel, and \tocref and their usage
+%              with verticals
+%
+
+\documentclass[12pt]{article}
+\usepackage{edXpsl} % edX style file
+
+\begin{document}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\begin{edXcourse}{1.00x}{1.00x Fall 2014}[url_name=2014_Fall showanswer=always start=2014-10-06T12:00]
+
+%%====================================== CHAPTER 1
+\begin{edXchapter}{Chapter 1}[start="2014-10-04T04:00"]
+
+%%-------------------------------------- SEQUENTIAL 1-1: Measureable Outcomes
+\begin{edXsequential}{A problem section}[due="2014-10-22T04:00" graded=true]
+
+\begin{edXtext}{Objective}
+
+Measurable outcomes for this section:
+\begin{enumerate}
+  \item \toclabel{mo:lesson} Follow a Lesson
+  \item \toclabel{mo:pset} Answer a problem set
+\end{enumerate}
+
+\end{edXtext}
+
+\end{edXsequential}
+
+%%--------------------------------------
+\end{edXchapter}
+
+%%====================================== CHAPTER 2
+\begin{edXchapter}{Chapter 2}[start="2014-10-06"]
+
+%%-------------------------------------- SEQUENTIAL 2-1: Lecture 1
+\begin{edXsequential}{A lecture section}
+
+\begin{edXvertical}{A set of texts in a lesson}
+\tocref{mo:lesson}
+
+\begin{edXtext}{Example text}[url_name="text-L1"]
+
+In this section are some equations.
+
+Example equation:
+\begin{equation}
+  \label{eq:deriv}
+  \frac{d}{dx} e^x = e^x
+\end{equation}
+
+Example equation array:
+\begin{eqnarray}
+  z & = x \times y \label{eq:com1}\\
+  z & = y \times x \label{eq:com2}
+\end{eqnarray}
+
+The fact that for scalars Equation \ref{eq:com1} is equal to Equation \ref{eq:com2} is known as the commutative property.
+
+The label for this reference \ref{eq:unused} has not been defined.
+
+\end{edXtext}
+
+\end{edXvertical}
+
+\end{edXsequential}
+
+%%-------------------------------------- SEQUENTIAL 2-2: Problem Set 1
+\begin{edXsequential}{Another lecture section}
+
+\begin{edXvertical}{A vertical grouping}
+\tocref{mo:pset}
+
+\begin{edXtext}{Problem Set 1}
+
+In this sequential, we have a vertical element with introductory text and a Figure \ref{fig:examplefig}.
+\begin{figure}
+  \begin{center}
+    \includegraphics{example-image.png}
+    \caption{Example single figure}
+    \label{fig:examplefig}
+  \end{center}
+\end{figure}
+
+\end{edXtext}
+
+\begin{edXproblem}{Example Problem 1}{url_name="p1"}
+
+Followed by a problem with an Equation \ref{eq:sum}.
+\begin{equation}
+  \boxed{A = B + C}
+  \label{eq:sum}
+\end{equation}
+
+\end{edXproblem}
+
+\end{edXvertical}
+
+\end{edXsequential}
+
+%%--------------------------------------
+\end{edXchapter}
+
+%%======================================
+\end{edXcourse}
+
+\end{document}


### PR DESCRIPTION
The commits contained in this PR most notably achieve the following:
-The automated equation numbering is handled by plasTeX assigned equation numbers
-The default addition of parentheses surrounding equation references has been removed (to stay true to LaTeX)
-For those that do not wish to use the automated equation formatting to a table with equation numbers, edXmath can now be made into a macro.

NOTE: The redefinition or use of the edXmath environment in a macro is challenging due to the fact that this is a verbatim environment, and plasTeX does not properly handle the standard LaTeX usage.  So here is an example of a macro environment (named 'eqa') which creates an align equation environment for MathJax rendering (both the newenvironment and providecommand are required):
\newenvironment{eqa}{\edXmath \begin{align}}{\end{align}\endedXmath}
\providecommand{\endeqa}{\endedXmath}

Additional minor modifications:
-The tocref command can now be used at the vertical level (instead of simply problem and text/html)
-Trailing_text is now a feature for formulaequationinput type