### PR TITLE
Cleaning up solution formatting

### DIFF
--- a/latex2edx/render/edXpsl.zpts
+++ b/latex2edx/render/edXpsl.zpts
@@ -50,7 +50,7 @@ name: edXdndtex
 <edxdndtex tal:attributes="linenum string:${self/attributes/linenum}; attrib_string self/attributes/attrib_string" tal:content='self'></edxdndtex>
 
 name: edXsolution
-<solution><font color="blue">Answer: </font><font color="blue" tal:content='self'></font></solution>
+<solution><p><b>Solution:</b></p><span tal:content='self'></span></solution>
 
 name: edXscript
 <script type="text/python" system_path="python_lib" tal:attributes="linenum string:${self/attributes/linenum}; filename string:${self/attributes/filename}" tal:content='self'></script>


### PR DESCRIPTION
Solutions are presently styled by inserting a <font color="blue"> tag in everything. This is outdated, and mostly overwritten by CSS styling (though sometimes it's not, which leads to random bits of blue appearing for no reason). This simple PR makes the solutions look a bit nicer.

In particular, enumerate and itemize bullets are randomly blue, as is text in centered environments.