### PR TITLE
Href hotfix

### DIFF
--- a/latex2edx/plastexpy/edXpsl.py
+++ b/latex2edx/plastexpy/edXpsl.py
@@ -127,6 +127,7 @@ class edXlti(Base.Command):
     args = '{ display_name } { launch_url } { lti_id } [ attrib_string ] self'
     # args = 'self'
 
+
 class edXdiscussion(Base.Command):
     args = '{ display_name } { attrib_string } self'
 
@@ -241,7 +242,7 @@ class index(Base.Command):
 
 
 class href(Base.Command):
-    args = '{ url } self'
+    args = '{ url } { self }'
 
 
 class textwidth(Base.Command):

--- a/latex2edx/render/edXpsl.zpts
+++ b/latex2edx/render/edXpsl.zpts
@@ -104,8 +104,7 @@ name: index
 <index tal:content='self'></index>
 
 name: href
-<a tal:condition="python:len(self)" target="_blank" tal:attributes="href string:${self/attributes/url}" tal:content='self'></a>
-<a tal:condition="python:len(self)==0" target="_blank" tal:attributes="href string:${self/attributes/url}" tal:content='self/attributes/url'></a>
+<a tal:condition="python:len(self)" target="_blank" tal:attributes="href string:${self/attributes/url}" tal:content='self'></a><a tal:condition="python:len(self)==0" target="_blank" tal:attributes="href string:${self/attributes/url}" tal:content='self/attributes/url'></a>
 
 name: textwidth
 \textwidth


### PR DESCRIPTION
Fixed behavior of href command.  Can be used to just specify a link with the URL, or both the URL and a link text.
Removed the carriage return.