### PR TITLE
Bugfix: config file import

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1707,8 +1707,9 @@ def CommandLine():
     config = DEFAULT_CONFIG
     # load local configuration file if available
     if os.path.exists(opts.config_file):
-        lc = __import__(opts.config_file, fromlist=['local_config'])
-        config.update(lc.local_config)
+        import imp
+        cf = imp.load_source('config_file', opts.config_file)
+        config.update(getattr(cf, 'local_config', {}))
 
     c = latex2edx(fn, verbose=opts.verbose, output_fn=opts.output_fn,
                   output_dir=opts.output_dir,


### PR DESCRIPTION
The `-c`/`--config-file` CLI option wasn't working for me; looks like `__import__` doesn't work with file paths, so fixed it by using `imp.load_source` instead and it seems to work (no automated tests though).

I realize that `config` isn't actually used anywhere in the code at the moment, but I have another PR that I'd like to submit which depends on loading a config file, so figured I'd fix this first =)