### PR TITLE
Expose "extra_xml_filters" option within the config file

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1705,11 +1705,15 @@ def CommandLine():
     fn = args[0]
 
     config = DEFAULT_CONFIG
+    extra_xml_filters = []
     # load local configuration file if available
     if os.path.exists(opts.config_file):
         import imp
+        # prepend the config file's directory to the path to allow local imports inside it
+        sys.path.insert(0, os.path.dirname(opts.config_file))
         cf = imp.load_source('config_file', opts.config_file)
         config.update(getattr(cf, 'local_config', {}))
+        extra_xml_filters.extend(getattr(cf, 'extra_xml_filters', []))
 
     c = latex2edx(fn, verbose=opts.verbose, output_fn=opts.output_fn,
                   output_dir=opts.output_dir,
@@ -1722,5 +1726,6 @@ def CommandLine():
                   units_only=opts.units_only,
                   popup_flag=opts.popups,
                   allow_dirs=opts.allow_dirs,
+                  extra_xml_filters=extra_xml_filters,
                   )
     c.convert()


### PR DESCRIPTION
This PR exposes the existing `extra_xml_filters` argument provided by the `latex2edx` class to course authors. Such filters allow arbitrary transformations to be applied to the course XML before it is written to disk, which is useful for things like including some custom JavaScript in every vertical.

Extra xml filters are specified by adding them to an array named `extra_xml_filters` in a latex2edx config file (see the existing `-c`/`--config-file` argument in the latex2edx CLI). The following example defines a simple filter which adds a footer to every vertical in the course:

```python
# File: config.py
# Use this file in your build with `latex2edx -c config.py`
from lxml import etree

def add_footer(xml):
    for vertical in xml.xpath('.//vertical'):
        vertical.append(etree.XML('<html>Hello World!</html>'))

extra_xml_filters = [add_footer]
```

Filters may also be imported into the config file from other python modules:

```python
# File: config.py
# Use this file in your build with `latex2edx -c config.py`
from my_filters import add_footer
extra_xml_filters = [add_footer]
```
```python
# File: my_filters.py (in same folder as config.py)
from lxml import etree

def add_footer(xml):
    for vertical in xml.xpath('.//vertical'):
        vertical.append(etree.XML('<html>Hello World!</html>'))
```
Ping @ichuang @evheubel for review.