### PR TITLE
Bugfix: jsinput "sop" attribute wasn't being copied

### DIFF
--- a/latex2edx/abox.py
+++ b/latex2edx/abox.py
@@ -333,7 +333,7 @@ class AnswerBox(object):
                 abxml.set('cfn_extra_args', 'options')  # tells sandbox to include 'options' in cfn call arguments
 
             js = etree.Element('jsinput')
-            jsattribs = ['width', 'height', 'gradefn', 'get_statefn', 'set_statefn', 'html_file']
+            jsattribs = ['width', 'height', 'gradefn', 'get_statefn', 'set_statefn', 'html_file', 'sop']
             for jsa in jsattribs:
                 self.copy_attrib(abargs, jsa, js)
             abxml.append(js)


### PR DESCRIPTION
The "sop" (= same origin policy) attribute of jsinput problems is used by the edX platform to determine the appropriate means of communicating with the jsinput iframe. This bugfix adds it to the list of attributes which need to be copied into the XML for jsinput problems.