### PR TITLE
Don't number unnumbered equations

### DIFF
--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -897,7 +897,7 @@ class latex2edx(object):
                 eqnnumcell = None
                 eqnlabel = []
                 for td in tr.findall('.//td'):
-                    if td.get('class') == 'eqnnum':
+                    if td.get('class') == 'eqnnum' and td.text != u'\u00A0':
                         eqnnumcell = td
                         # EVH: Use plasTeX output to handle equation numbering
                         eqncnt += 1


### PR DESCRIPTION
The code that created better equations numbers did not account for unnumbered equations. So it accidentally numbered every equation. The additional condition fixes that case.