### PR TITLE
second optional argument for includegraphics

### DIFF
--- a/latex2edx/plastexpy/edXpsl.py
+++ b/latex2edx/plastexpy/edXpsl.py
@@ -133,7 +133,7 @@ class edXdiscussion(Base.Command):
 
 
 class includegraphics(Base.Command):
-    args = '[ width ] self'
+    args = '[ width ] [ alt ] self'
 
 
 class marginote(Base.Command):  # tooltip margin note \marginote[options]{note}{anchor text}

--- a/latex2edx/render/edXpsl.zpts
+++ b/latex2edx/render/edXpsl.zpts
@@ -74,7 +74,7 @@ name: edXdiscussion
 <discussion tal:attributes='display_name self/attributes/display_name; attrib_string self/attributes/attrib_string' tal:content='self'></discussion>
 
 name: includegraphics
-<includegraphics tal:attributes="style string:${self/attributes/width}" tal:content='self'></includegraphics>
+<includegraphics tal:attributes="style string:${self/attributes/width}; alt string:${self/attributes/alt}" tal:content='self'></includegraphics>
 
 name: edXcite
 <edxcite tal:attributes="ref string:${self/attributes/ref}" tal:content='self'></edxcite>


### PR DESCRIPTION
modified edXpsl.zpts and edXpsl.py so that there is a second optional argument where one can add alt text for images