### PR TITLE
Jfrench showhide modified to meet accessibility standards

### DIFF
--- a/latex2edx/latex2edx.css
+++ b/latex2edx/latex2edx.css
@@ -44,6 +44,14 @@
  border-radius: 6px;
 }
 
+.hideshowh3 {
+  display: inline-block;
+  margin: 0px 0px 0px 0px;
+  font-family: inherit;
+  font-size: 1.05em;
+  font-weight: 600;
+}
+
 button.hideshowheader {
   /* Some "none"s needed to override edX defaults */
    display: block;

--- a/latex2edx/latex2edx.css
+++ b/latex2edx/latex2edx.css
@@ -1,3 +1,17 @@
+.arrow {
+  border: solid black;
+  border-width: 0 3px 3px 0;
+  display: inline-block;
+  padding: 3px;
+}
+.down {
+  transform: rotate(-45deg);
+  -webkit-transform: rotate(-45deg);
+}
+.up {
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+}
 .hideshowbox h4 {
  background-color: #F0F0F0;
  color: black;

--- a/latex2edx/latex2edx.css
+++ b/latex2edx/latex2edx.css
@@ -1,69 +1,85 @@
-.arrow {
+.hideshowarrow {
   border: solid black;
   border-width: 0 3px 3px 0;
   display: inline-block;
   padding: 3px;
 }
-.down {
+.hideshowarrow.down {
   transform: rotate(-45deg);
   -webkit-transform: rotate(-45deg);
 }
-.up {
+.hideshowarrow.up {
   transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
 }
 
 .hideshowbox .hideshowbottom {
-  background-color: #F8F8F8;
-  color: black;
-  padding: 0px 5px 1px 3px;
-  margin: 0px;
-  font-size: 1.05em;
-  text-align: right;
-  border: solid #C4C5C7;
-  border-width: 1px 0px 0px 0px;
-  border-bottom-right-radius: 5px;
-  border-bottom-left-radius: 5px;
-  cursor: pointer;
+ background-color: #F8F8F8;
+ color: black;
+ padding: 0px 5px 1px 3px;
+ margin: 0px;
+ font-size: 1.05em;
+ text-align: right;
+ border: solid #C4C5C7;
+ border-width: 1px 0px 0px 0px;
+ border-bottom-right-radius: 5px;
+ border-bottom-left-radius: 5px;
+ cursor: pointer;
 }
 
 .hideshowcontent p {
-  margin: 0px 0px 7px 0px;
+ margin: 0px 0px 7px 0px;
 }
 
 .hideshowcontent {
-  display: none;
-  padding: 10px 10px 4px 10px;
-  background-color: #FFF;
+ display: none;
+ padding: 10px 10px 4px 10px;
+ background-color: #FFF;
 }
 
 .hideshowbox {
-  border: 1px solid #C4C5c7;
-  background-color: #C4C5c7;
-  margin: 22px 5px;
-  border-radius: 6px;
+ border: 1px solid #C4C5c7;
+ background-color: #C4C5c7;
+ margin: 22px 5px;
+ border-radius: 6px;
 }
 
 button.hideshowheader {
-  display:block;
-  width:100%;
-  margin:0px;
+  /* Some "none"s needed to override edX defaults */
+   display: block;
+   width: 100%;
+   margin: 0px;
 
-  font-size: 1.05em;
-  font-weight: 600;
-  line-height: 1.4em;
+   font-size: 1.05em;
+   font-weight: 600;
 
-  text-align:left;
+   text-align: left;
+   background-image: none;
+   background-color: #F0F0F0;
+   color: black;
+
+   padding: 2px 4px 3px 6px;
+
+   border: 0px solid black;
+   border-top-right-radius: 5px;
+   border-top-left-radius: 5px;
+   border-radius: 6px 6px 0px 0px; /* affects background-color radius. Should match the containing div */
+   box-shadow: none;
+
+   cursor: pointer;
+   font-family: inherit;
+}
+
+button.hideshowheader:hover {
+  border: 0px solid black;
   background-color: #F0F0F0;
-  background-image: linear-gradient(#F0F0F0,#F0F0F0);
-  color: black;
+  background-image: none;
+  box-shadow: none;
+}
 
-  padding: 2px 4px 3px 6px;
-
-  border:0px solid black;
-  border-top-right-radius: 5px;
-  border-top-left-radius: 5px;
-
-  cursor: pointer;
-  font-family: inherit;
+button.hideshowheader:active, button.hideshowheader:focus {
+  border: 0px solid black;
+  background-color: #F0F0F0;
+  background-image: none;
+  box-shadow: none;
 }

--- a/latex2edx/latex2edx.css
+++ b/latex2edx/latex2edx.css
@@ -12,51 +12,58 @@
   transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
 }
-.hideshowbox h4 {
- background-color: #F0F0F0;
- color: black;
- padding: 2px 4px 3px 6px;
- margin: 0px;
- border-top-right-radius: 5px;
- border-top-left-radius: 5px;
- font-size: 1.05em;
- font-weight: 600;
- line-height: 1.4em;
- cursor: pointer;
-}
 
 .hideshowbox .hideshowbottom {
- background-color: #F8F8F8;
- color: black;
- padding: 0px 5px 1px 3px;
- margin: 0px;
- font-size: 1.05em;
- text-align: right;
- border: solid #C4C5C7;
- border-width: 1px 0px 0px 0px;
- border-bottom-right-radius: 5px;
- border-bottom-left-radius: 5px;
- cursor: pointer;
-}
-
-.hideshowbox .toggleimage {
- padding: 0px 4px 0px 4px;
- float: right;
+  background-color: #F8F8F8;
+  color: black;
+  padding: 0px 5px 1px 3px;
+  margin: 0px;
+  font-size: 1.05em;
+  text-align: right;
+  border: solid #C4C5C7;
+  border-width: 1px 0px 0px 0px;
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
+  cursor: pointer;
 }
 
 .hideshowcontent p {
- margin: 0px 0px 7px 0px;
+  margin: 0px 0px 7px 0px;
 }
 
 .hideshowcontent {
- display: none;
- padding: 10px 10px 4px 10px;
- background-color: #FFF;
+  display: none;
+  padding: 10px 10px 4px 10px;
+  background-color: #FFF;
 }
 
 .hideshowbox {
- border: 1px solid #C4C5c7;
- background-color: #C4C5c7;
- margin: 22px 5px;
- border-radius: 6px;
+  border: 1px solid #C4C5c7;
+  background-color: #C4C5c7;
+  margin: 22px 5px;
+  border-radius: 6px;
+}
+
+button.hideshowheader {
+  display:block;
+  width:100%;
+  margin:0px;
+
+  font-size: 1.05em;
+  font-weight: 600;
+  line-height: 1.4em;
+
+  text-align:left;
+  background-color: #F0F0F0;
+  background-image: linear-gradient(#F0F0F0,#F0F0F0);
+  color: black;
+
+  padding: 2px 4px 3px 6px;
+
+  border:0px solid black;
+  border-top-right-radius: 5px;
+  border-top-left-radius: 5px;
+
+  cursor: pointer;
+  font-family: inherit;
 }

--- a/latex2edx/latex2edx.js
+++ b/latex2edx/latex2edx.js
@@ -4,6 +4,7 @@
  * The MIT Licence (MIT)
 
  * Copyright (c) 2014-2015 Jolyon Bloomfield and Eric Heubel
+ * Modifed 2021 by Duncan Levear and Rich Calogerro
 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -11,25 +12,7 @@
 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 function hideshow(object) {
-  // Check to ensure that an attempt has been made
-  submissions = $(object).parents('.problem').find('.submission_feedback');
-  showanswerbutton = $(object).parents('.problem').find('.show');
-  if ($(submissions) && !$(showanswerbutton)) {
-      submissiontext = $(submissions).text().trim();
-      poscut = parseInt(submissiontext.indexOf("of"));
-      if (submissiontext.substring(14, poscut) == '0') {
-          alert('You must make an attempt before viewing the solution.');
-          return false;
-      }
-  }
-
-  // If checks succeed proceed with show/hide
-  hideshownocheck(object);
-}
-
-function hideshownocheck(object) {
   // Do the show/hide business
   stuff = $(object).parents('.hideshowbox').find('.hideshowcontent');
   text = $(object).parents('.hideshowbox').find('.hideshowbottom');
@@ -39,11 +22,13 @@ function hideshownocheck(object) {
       $(stuff).slideUp('slow');
       $(text).html('<a href="javascript: {return false;}">Show</a>');
       newclass = arrowclass.replace('up', 'down');
+      $(object).attr('aria-expanded','false');
       $(arrow).attr('class', newclass);
   } else {
       $(stuff).slideDown('slow');
       $(text).html('<a href="javascript: {return false;}">Hide</a>');
       newclass = arrowclass.replace('down', 'up');
+      $(object).attr('aria-expanded','true');
       $(arrow).attr('class', newclass);
   }
 }

--- a/latex2edx/latex2edx.js
+++ b/latex2edx/latex2edx.js
@@ -16,7 +16,7 @@ function hideshow(object) {
   // Do the show/hide business
   stuff = $(object).parents('.hideshowbox').find('.hideshowcontent');
   text = $(object).parents('.hideshowbox').find('.hideshowbottom');
-  arrow = $(object).parents('.hideshowbox').find('.arrow');
+  arrow = $(object).parents('.hideshowbox').find('.hideshowarrow');
   arrowclass = $(arrow).attr('class');
   if ($(stuff).css('display') != 'none') {
       $(stuff).slideUp('slow');
@@ -31,4 +31,4 @@ function hideshow(object) {
       $(object).attr('aria-expanded','true');
       $(arrow).attr('class', newclass);
   }
-}
+      }

--- a/latex2edx/latex2edx.js
+++ b/latex2edx/latex2edx.js
@@ -17,18 +17,19 @@ function hideshow(object) {
   stuff = $(object).parents('.hideshowbox').find('.hideshowcontent');
   text = $(object).parents('.hideshowbox').find('.hideshowbottom');
   arrow = $(object).parents('.hideshowbox').find('.hideshowarrow');
+  button = $(object).parents('.hideshowbox').find('.hideshowheader')
   arrowclass = $(arrow).attr('class');
   if ($(stuff).css('display') != 'none') {
       $(stuff).slideUp('slow');
       $(text).html('<a href="javascript: {return false;}">Show</a>');
       newclass = arrowclass.replace('up', 'down');
-      $(object).attr('aria-expanded','false');
+      $(button).attr('aria-expanded','false');
       $(arrow).attr('class', newclass);
   } else {
       $(stuff).slideDown('slow');
       $(text).html('<a href="javascript: {return false;}">Hide</a>');
       newclass = arrowclass.replace('down', 'up');
-      $(object).attr('aria-expanded','true');
+      $(button).attr('aria-expanded','true');
       $(arrow).attr('class', newclass);
   }
-      }
+}

--- a/latex2edx/latex2edx.js
+++ b/latex2edx/latex2edx.js
@@ -33,7 +33,7 @@ function hideshownocheck(object) {
   // Do the show/hide business
   stuff = $(object).parents('.hideshowbox').find('.hideshowcontent');
   text = $(object).parents('.hideshowbox').find('.hideshowbottom');
-  arrow = $(object).parents('.hideshowbox').find('.toggleimage');
+  arrow = $(object).parents('.hideshowbox').find('.arrow');
   arrowclass = $(arrow).attr('class');
   if ($(stuff).css('display') != 'none') {
       $(stuff).slideUp('slow');

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1437,6 +1437,7 @@ class latex2edx(object):
             scriptforsh = etree.Element('SCRIPT',
                                         {'type': 'text/javascript',
                                          'src': '/static/latex2edx.js'})
+            scriptforsh.text = " "
             styleforsh = etree.Element('LINK',
                                        {'type': 'text/css',
                                         'rel': 'stylesheet',

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1410,25 +1410,25 @@ class latex2edx(object):
             desc = showhide.get('description', '')
             oneup = showhide.getparent()
             newsh = etree.SubElement(oneup, 'div', {'class': 'hideshowbox'})
-            sub1 = etree.SubElement(newsh, 'h4',
-                                    {'aria-expanded':'false', 'tabindex':'0', 'onclick': 'hideshow(this);',
-                                     'style': 'margin: 0px'})
+            sub1 = etree.SubElement(newsh, 'button',
+                                    {'aria-expanded':'false', 'class':'hideshowheader', 'onclick': 'hideshow(this);'})
             sub2 = etree.SubElement(sub1, 'span',
                              {'class': 'arrow down'})
             sub2.text = ' '
-            sub2.tail = desc
+            sub2.tail = ' ' + desc
             newsh.append(showhide)
             showhide.tag = 'div'  # change edxshowhide tag
             if 'description' in showhide.attrib:
                 showhide.attrib.pop('description')  # remove description
             showhide.set('class', 'hideshowcontent')
-            sub2 = etree.SubElement(newsh, 'p',
+            showhide.set('tabindex','0')
+            sub3 = etree.SubElement(newsh, 'p',
                                     {'class': 'hideshowbottom',
                                      'onclick': 'hideshow(this);',
                                      'style': 'margin: 0px'})
-            subsub2 = etree.SubElement(sub2, 'a',
+            subsub3 = etree.SubElement(sub3, 'a',
                                        {'href': 'javascript: {return false;}'})
-            subsub2.text = 'Show'
+            subsub3.text = 'Show'
             try:
                 par = self.find_container_root(newsh, "showhide")
             except Exception as err:

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -191,7 +191,6 @@ class latex2edx(object):
                             self.process_custom_html,
                             self.process_marginote,
                             self.process_general_hint_system,
-                            self.unindent_edXscripts,
                             self.check_all_python_scripts,
                             self.handle_policy_settings,
                             self.process_add_timestamp,
@@ -437,52 +436,6 @@ class latex2edx(object):
                 suppress_policy_settings(chapter)
                 for sequential in chapter.findall('.//sequential'):
                     suppress_policy_settings(sequential)
-
-    @staticmethod
-    def unindent_edXscripts(tree):
-        '''
-        Remove common indentation from lines in <script> elements
-        '''
-        def first_nonempty_entry(L):
-            '''
-            Return first element in L for which x.strip() is not the empty string.
-            '''
-            for x in L:
-              if len(x.strip()) != 0:
-                  return x
-            return -1
-
-        def unindent(fstring):
-            '''
-            Filter lines to remove common indentation.
-
-            EXAMPLE
-              --a.txt--
-                 def f(x):
-                     return x*x
-              ---------
-              --python--
-              fstring = open('a.txt').read()
-              x = unindent(fstring)
-              open('b.txt','w').write(x)
-              ---------
-              --b.txt--
-              def f(x):
-                  return x*x
-              --------
-            '''
-            lines = fstring.split("\n")
-            fne = first_nonempty_entry(lines)
-            if fne == -1:
-                # empty edXscript, skip
-                return fstring
-            extraSpace = len(fne) - len(fne.lstrip(' '))
-            newlines = [L[extraSpace:].rstrip() for L in lines]
-            return "\n".join(newlines)
-
-        for script in tree.findall('.//script'):
-            if script.text is not None:
-                script.text = unindent(script.text)
 
     @staticmethod
     def fix_table(tree):

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -33,7 +33,7 @@ from .abox import split_args_with_quoted_strings
 
 DEFAULT_CONFIG = {
     'problem_default_attributes': {
-        'showanswer': 'closed',
+        'showanswer': 'never',
         'rerandomize': 'never',
     }
 }
@@ -191,6 +191,7 @@ class latex2edx(object):
                             self.process_custom_html,
                             self.process_marginote,
                             self.process_general_hint_system,
+                            self.unindent_edXscripts,
                             self.check_all_python_scripts,
                             self.handle_policy_settings,
                             self.process_add_timestamp,
@@ -436,6 +437,52 @@ class latex2edx(object):
                 suppress_policy_settings(chapter)
                 for sequential in chapter.findall('.//sequential'):
                     suppress_policy_settings(sequential)
+
+    @staticmethod
+    def unindent_edXscripts(tree):
+        '''
+        Remove common indentation from lines in <script> elements
+        '''
+        def first_nonempty_entry(L):
+            '''
+            Return first element in L for which x.strip() is not the empty string.
+            '''
+            for x in L:
+              if len(x.strip()) != 0:
+                  return x
+            return -1
+
+        def unindent(fstring):
+            '''
+            Filter lines to remove common indentation.
+
+            EXAMPLE
+              --a.txt--
+                 def f(x):
+                     return x*x
+              ---------
+              --python--
+              fstring = open('a.txt').read()
+              x = unindent(fstring)
+              open('b.txt','w').write(x)
+              ---------
+              --b.txt--
+              def f(x):
+                  return x*x
+              --------
+            '''
+            lines = fstring.split("\n")
+            fne = first_nonempty_entry(lines)
+            if fne == -1:
+                # empty edXscript, skip
+                return fstring
+            extraSpace = len(fne) - len(fne.lstrip(' '))
+            newlines = [L[extraSpace:].rstrip() for L in lines]
+            return "\n".join(newlines)
+
+        for script in tree.findall('.//script'):
+            if script.text is not None:
+                script.text = unindent(script.text)
 
     @staticmethod
     def fix_table(tree):
@@ -1410,18 +1457,21 @@ class latex2edx(object):
             desc = showhide.get('description', '')
             oneup = showhide.getparent()
             newsh = etree.SubElement(oneup, 'div', {'class': 'hideshowbox'})
-            sub1 = etree.SubElement(newsh, 'button',
-                                    {'aria-expanded':'false', 'class':'hideshowheader', 'onclick': 'hideshow(this);'})
-            sub2 = etree.SubElement(sub1, 'span',
-                             {'class': 'hideshowarrow down'})
-            sub2.text = ' '
-            sub2.tail = ' ' + desc
+            sub0 = etree.SubElement(newsh, 'button',
+                                    {'aria-expanded':'false', 
+                                    'class':'hideshowheader', 
+                                    'onclick': 'hideshow(this);'})
+            sub1 = etree.SubElement(sub0, 'span', 
+                                    {'class': 'hideshowarrow down'})
+            sub1.text = ' '
+            sub2 = etree.SubElement(sub0, 'h3', 
+                                    {'class':'hideshowh3'})
+            sub2.text = ' ' + desc
             newsh.append(showhide)
             showhide.tag = 'div'  # change edxshowhide tag
             if 'description' in showhide.attrib:
                 showhide.attrib.pop('description')  # remove description
             showhide.set('class', 'hideshowcontent')
-            showhide.set('tabindex','0')
             sub3 = etree.SubElement(newsh, 'p',
                                     {'class': 'hideshowbottom',
                                      'onclick': 'hideshow(this);',

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1411,12 +1411,12 @@ class latex2edx(object):
             oneup = showhide.getparent()
             newsh = etree.SubElement(oneup, 'div', {'class': 'hideshowbox'})
             sub1 = etree.SubElement(newsh, 'h4',
-                                    {'onclick': 'hideshow(this);',
+                                    {'aria-expanded':'false', 'tabindex':'0', 'onclick': 'hideshow(this);',
                                      'style': 'margin: 0px'})
             sub2 = etree.SubElement(sub1, 'span',
                              {'class': 'arrow down'})
-            sub1.text = desc
             sub2.text = ' '
+            sub1.tail = desc
             newsh.append(showhide)
             showhide.tag = 'div'  # change edxshowhide tag
             if 'description' in showhide.attrib:

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1416,7 +1416,7 @@ class latex2edx(object):
             sub2 = etree.SubElement(sub1, 'span',
                              {'class': 'arrow down'})
             sub2.text = ' '
-            sub1.tail = desc
+            sub2.tail = desc
             newsh.append(showhide)
             showhide.tag = 'div'  # change edxshowhide tag
             if 'description' in showhide.attrib:

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1413,7 +1413,7 @@ class latex2edx(object):
             sub1 = etree.SubElement(newsh, 'button',
                                     {'aria-expanded':'false', 'class':'hideshowheader', 'onclick': 'hideshow(this);'})
             sub2 = etree.SubElement(sub1, 'span',
-                             {'class': 'arrow down'})
+                             {'class': 'hideshowarrow down'})
             sub2.text = ' '
             sub2.tail = ' ' + desc
             newsh.append(showhide)

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -1413,9 +1413,10 @@ class latex2edx(object):
             sub1 = etree.SubElement(newsh, 'h4',
                                     {'onclick': 'hideshow(this);',
                                      'style': 'margin: 0px'})
+            sub2 = etree.SubElement(sub1, 'span',
+                             {'class': 'arrow down'})
             sub1.text = desc
-            etree.SubElement(sub1, 'span',
-                             {'class': 'icon-caret-down toggleimage'})
+            sub2.text = ' '
             newsh.append(showhide)
             showhide.tag = 'div'  # change edxshowhide tag
             if 'description' in showhide.attrib:

--- a/latex2edx/main.py
+++ b/latex2edx/main.py
@@ -33,7 +33,7 @@ from .abox import split_args_with_quoted_strings
 
 DEFAULT_CONFIG = {
     'problem_default_attributes': {
-        'showanswer': 'never',
+        'showanswer': 'closed',
         'rerandomize': 'never',
     }
 }


### PR DESCRIPTION
The current version builds html that has been approved by both Mary Ziegler and Rich, we also removed some old javascript from latex2edx.js that no longer functions.

This showhide uses a button and an h3 element to best support keyboard control and screen reader access to content.