### PR TITLE
Updating plastex version in setup.py also

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         },
     install_requires=['lxml',
                       'path.py',
-                      'plastex',
+                      'plastex==2.1',
                       'beautifulsoup4',
                       'latex2dnd',
                       'pyyaml',


### PR DESCRIPTION
Didn't realize that pip install was loading everything from setup.py, which refers to the pypi repository rather than the github repo. This points setup.py to the older version of plastex also.